### PR TITLE
Wrap info-text under year filter select on tablet or smaller

### DIFF
--- a/assets/styles/ui-components/_archive-filters.scss
+++ b/assets/styles/ui-components/_archive-filters.scss
@@ -24,6 +24,12 @@
             }
         }
 
+        &--sort-by-container {
+            select {
+                min-width: 84px;
+            }
+        }
+
         input[type="text"] {
             border-radius: 0 !important;
 
@@ -42,6 +48,13 @@
 
         .align-items-end {
             align-items: flex-end;
+        }
+
+        @include until($tablet) {
+            .column {
+                flex-wrap: wrap;
+                gap: 6px;
+            }
         }
     }
 }


### PR DESCRIPTION
Task: https://geniemdev.atlassian.net/browse/TMS-913

Fix: Added wrapping for exhibitions year filter info-text on tablets or smaller screens
