### PR TITLE
TMS-1190: Add height to single exhibition hero on large monitors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1190: Add height to single exhibition hero on large monitors
+
 ## [1.9.1] - 2025-08-13
 
 - TMS-1160: Fix elements focus outline thickness

--- a/assets/styles/views/_single-exhibition.scss
+++ b/assets/styles/views/_single-exhibition.scss
@@ -4,6 +4,10 @@
             height: unset;
             min-height: 41.666vw;
         }
+
+        @media (min-width: 2200px) {
+            min-height: 38vw;
+        }
     }
 
     .entry {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1190 Artikkelikuvien skaalautuminen meganäytöillä
Task: https://hiondigital.atlassian.net/browse/TMS-1190

## Description
Increase hero-image height for wide viewports to prevent images from cutting off

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

